### PR TITLE
some VBF headers can contain newline instead of space in the 'header {'

### DIFF
--- a/vbffile.cpp
+++ b/vbffile.cpp
@@ -119,6 +119,8 @@ bool vbf_open(const QString & fileName, vbf_t & vbf)
 
 	//looking for such template: header { }
 	offset = h.indexOf("header {");
+	if (offset < 0)
+		offset = h.indexOf("header\n{");
 	if (offset == -1) {
 		qWarning() << "can't find begin of header";
 		infile.close();


### PR DESCRIPTION
I found a VBF that starts with a such pattern
```
vbf_version = 3.1;
header
{

   // Copyright Ford Motor Company.
...
```
Your actual code can parse only `header {` string (without newline).

Hope this fix will be enough (there are no files with `header\r\n{`, `header <several spaces> {`, etc).